### PR TITLE
[Kahi_scienti_works] and [Kahi_minciencias_opendata_person] COD_RH id adjustments

### DIFF
--- a/Kahi_minciencias_opendata_person/kahi_minciencias_opendata_person/Kahi_minciencias_opendata_person.py
+++ b/Kahi_minciencias_opendata_person/kahi_minciencias_opendata_person/Kahi_minciencias_opendata_person.py
@@ -146,8 +146,8 @@ def process_one(author, db, collection, empty_person, cvlac_profile, groups_prod
 
     entry["external_ids"].append({
         "provenance": "minciencias",
-        "source": "COD_RH",
-        "id": cvlac_profile["id_persona_pr"]
+        "source": "scienti",
+        "id": {"COD_RH": cvlac_profile["id_persona_pr"]}
     })
 
     # all the ids are mixed, so we need to check each one in the next columns


### PR DESCRIPTION
The way in which the COD_RH id is stored in the both plugins has been adjusted. also, logic is added to rescue DOIs from the TXT_WEB_PRODUCT field in the scienti data.

Required for:
- https://github.com/colav/impactu/issues/4
- https://github.com/colav/impactu/issues/14