### PR TITLE
[Kahi_post_person_work_cleaning] Avoid unassigning works if the author's COD_RH is in the work

### DIFF
--- a/Kahi_post_person_work_cleaning/kahi_post_person_work_cleaning/Kahi_post_person_work_cleaning.py
+++ b/Kahi_post_person_work_cleaning/kahi_post_person_work_cleaning/Kahi_post_person_work_cleaning.py
@@ -19,9 +19,24 @@ class Kahi_post_person_work_cleaning(KahiBase):
 
     def process_one(self, author):
         works = works = list(self.works.find(
-            {"authors.id": author["_id"]}, {"authors": 1}))
+            {"authors.id": author["_id"]}, {"authors": 1, "external_ids": 1}))
+        # Get the cod_rh from the author
+        cod_rh = next((x["id"]["COD_RH"] for x in author["external_ids"] if x["source"] in ("scienti", "minciencias")),
+                      None)
         for work in works:
+            # Check if the author has the cod_rh in the work
+            cod_rh_work = [
+                x["id"]["COD_RH"]
+                for x in work["external_ids"]
+                if x.get("source") == "scienti" and "COD_RH" in x.get("id", {})
+            ]
+            if cod_rh in cod_rh_work:
+                # The author has the cod_rh in the work
+                continue
+
+            # Check if the author has the affiliation in the work
             for j, work_author in enumerate(work["authors"]):
+                # Only analyze the author we are looking for in the work
                 if work_author["id"] == author["_id"]:
                     found = False
                     if not work_author["affiliations"]:
@@ -39,9 +54,9 @@ class Kahi_post_person_work_cleaning(KahiBase):
 
     def run(self):
         # https://github.com/colav/impactu/issues/141
-        # only authors from scienti, staff o ranking
+        # only authors from scienti, staff or ciarp
         authors = list(self.person.find({"$or": [{"updated.source": "scienti"}, {
-                       "updated.source": "staff"}, {"updated.source": "ranking"}]}, {"_id": 1, "affilations": 1}))
+                       "updated.source": "staff"}, {"updated.source": "ciarp"}]}, {"_id": 1, "external_ids": 1, "affilations": 1}))
         for author in authors:
             self.process_one(author)
         return 0


### PR DESCRIPTION
Related issues:
- https://github.com/colav/impactu/issues/343
- https://github.com/colav/impactu/issues/214