### PR TITLE
[postcalculations] add h-index and h5-index calculations; update indexes for efficiency

### DIFF
--- a/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/denormalization.py
+++ b/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/denormalization.py
@@ -1,5 +1,6 @@
 from joblib import Parallel, delayed
-
+from datetime import datetime
+from pymongo import UpdateOne
 
 PARALLEL_SAFE_COLLECTIONS = {"sources", "person", "affiliations"}
 WORKS_DATES_CHUNK_BUCKETS = 16
@@ -102,6 +103,88 @@ def _run_chunked_aggregate_by_id(
         for range_info in ranges
     )
 
+def _compute_h_index(citations: list[int]) -> int:
+    """
+    Compute the h-index given a list of citation counts.
+    """
+    sorted_cits = sorted((c for c in citations if c is not None), reverse=True)
+    return sum(1 for i, c in enumerate(sorted_cits, 1) if c >= i)
+
+def _build_citations_pipeline(local_field: str, h5_start_year: int, h5_end_year: int) -> list:
+    """
+    Build the aggregation pipeline to compute h-index and h5-index.
+    """
+    return [
+        {
+            "$lookup": {
+                "from": "works",
+                "localField": "_id",
+                "foreignField": local_field,
+                "as": "work",
+                "pipeline": [
+                    {
+                        "$project": {
+                            "_id": 0,
+                            "year_published": 1,
+                            "citations_count_openalex": 1
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "$project": {
+                "_id": 1,
+                "all_citations": "$work.citations_count_openalex",
+                "h5_citations": {
+                    "$map": {
+                        "input": {
+                            "$filter": {
+                                "input": "$work",
+                                "as": "w",
+                                "cond": {
+                                    "$and": [
+                                        {"$gte": ["$$w.year_published", h5_start_year]},
+                                        {"$lte": ["$$w.year_published", h5_end_year]}
+                                    ]
+                                }
+                            }
+                        },
+                        "as": "w",
+                        "in": "$$w.citations_count_openalex"
+                    }
+                }
+            }
+        }
+    ]
+
+def _set_h_index_metrics(collection, into_collection_name, local_field) -> None:
+    """
+    Set h-index and h5-index for documents in the collection based on citations.
+    """
+    current_year = datetime.now().year
+    h5_start_year = current_year - 5
+    h5_end_year = current_year - 1
+
+    pipeline = _build_citations_pipeline(local_field, h5_start_year, h5_end_year)
+    cursor = collection.aggregate(pipeline, allowDiskUse=True)
+
+    bulk_ops = []
+    for doc in cursor:
+        h_index = _compute_h_index(doc.get("all_citations") or [])
+        h5_index = _compute_h_index(doc.get("h5_citations") or [])
+        bulk_ops.append(
+            UpdateOne(
+                {"_id": doc["_id"]},
+                {"$set": {"h_index": h_index, "h5_index": h5_index}}
+            )
+        )
+        if len(bulk_ops) >= 500:
+            collection.database[into_collection_name].bulk_write(bulk_ops, ordered=False)
+            bulk_ops = []
+
+    if bulk_ops:
+        collection.database[into_collection_name].bulk_write(bulk_ops, ordered=False)
 
 def set_works_authors_affiliations_country(collection) -> None:
     """
@@ -2577,6 +2660,21 @@ def normalize_source_topics(collection) -> None:
         allowDiskUse=True,
     )
 
+def set_person_h_index_metrics(collection) -> None:
+    target = collection.database["person"] if collection.name in ("works", "person") else collection
+    _set_h_index_metrics(
+        collection=target,
+        into_collection_name="person",
+        local_field="authors.id"
+    )
+
+def set_affiliations_h_index_metrics(collection) -> None:
+    target = collection.database["affiliations"] if collection.name in ("works", "affiliations") else collection
+    _set_h_index_metrics(
+        collection=target,
+        into_collection_name="affiliations",
+        local_field="authors.affiliations.id"
+    )
 
 DENORMALIZATION_PIPELINES = {
     "works": [
@@ -2608,9 +2706,11 @@ DENORMALIZATION_PIPELINES = {
     "person": [
         set_person_affiliations_relations,
         clean_person_empty_affiliations_array,
+        set_person_h_index_metrics,
     ],
     "affiliations": [
         set_affiliations_citations_count_openalex,
+        set_affiliations_h_index_metrics,
     ],
 }
 

--- a/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/denormalization.py
+++ b/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/denormalization.py
@@ -103,12 +103,14 @@ def _run_chunked_aggregate_by_id(
         for range_info in ranges
     )
 
+
 def _compute_h_index(citations: list[int]) -> int:
     """
     Compute the h-index given a list of citation counts.
     """
     sorted_cits = sorted((c for c in citations if c is not None), reverse=True)
     return sum(1 for i, c in enumerate(sorted_cits, 1) if c >= i)
+
 
 def _build_citations_pipeline(local_field: str, h5_start_year: int, h5_end_year: int) -> list:
     """
@@ -158,6 +160,7 @@ def _build_citations_pipeline(local_field: str, h5_start_year: int, h5_end_year:
         }
     ]
 
+
 def _set_h_index_metrics(collection, into_collection_name, local_field) -> None:
     """
     Set h-index and h5-index for documents in the collection based on citations.
@@ -185,6 +188,7 @@ def _set_h_index_metrics(collection, into_collection_name, local_field) -> None:
 
     if bulk_ops:
         collection.database[into_collection_name].bulk_write(bulk_ops, ordered=False)
+
 
 def set_works_authors_affiliations_country(collection) -> None:
     """
@@ -2660,6 +2664,7 @@ def normalize_source_topics(collection) -> None:
         allowDiskUse=True,
     )
 
+
 def set_person_h_index_metrics(collection) -> None:
     target = collection.database["person"] if collection.name in ("works", "person") else collection
     _set_h_index_metrics(
@@ -2668,6 +2673,7 @@ def set_person_h_index_metrics(collection) -> None:
         local_field="authors.id"
     )
 
+
 def set_affiliations_h_index_metrics(collection) -> None:
     target = collection.database["affiliations"] if collection.name in ("works", "affiliations") else collection
     _set_h_index_metrics(
@@ -2675,6 +2681,7 @@ def set_affiliations_h_index_metrics(collection) -> None:
         into_collection_name="affiliations",
         local_field="authors.affiliations.id"
     )
+
 
 DENORMALIZATION_PIPELINES = {
     "works": [

--- a/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
+++ b/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
@@ -57,5 +57,5 @@ def create_indexes(db):
     db["sources"].create_index({"licenses.type": 1})
     db["sources"].create_index({"topics.id": 1})
     # H-index and H5-index calculations require these indexes to be efficient
-    db["works"].create_index({ "authors.id": 1, "year_published": 1, "citations_count_openalex": 1 })
-    db["works"].create_index({ "authors.affiliations.id": 1, "year_published": 1, "citations_count_openalex": 1 });
+    db["works"].create_index({"authors.id": 1, "year_published": 1, "citations_count_openalex": 1})
+    db["works"].create_index({"authors.affiliations.id": 1, "year_published": 1, "citations_count_openalex": 1})

--- a/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
+++ b/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
@@ -56,3 +56,6 @@ def create_indexes(db):
     db["sources"].create_index({"publication_time_weeks": 1})
     db["sources"].create_index({"licenses.type": 1})
     db["sources"].create_index({"topics.id": 1})
+    # H-index and H5-index calculations require these indexes to be efficient
+    db["works"].create_index({ "authors.id": 1, "year_published": 1, "citations_count_openalex": 1 })
+    db["works"].create_index({ "authors.affiliations.id": 1, "year_published": 1, "citations_count_openalex": 1 });

--- a/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
+++ b/Kahi_impactu_postcalculations/kahi_impactu_postcalculations/indexes.py
@@ -9,27 +9,93 @@ def create_indexes(db):
     db : pymongo.database.Database
         Database object to create indexes on. (kahi)
     """
+
+    # =========================================================
+    # WORKS COLLECTION
+    # =========================================================
+
+    # Relations and references.
     db["works"].create_index({"groups.id": 1})
     db["works"].create_index({"source.id": 1})
-    db["works"].create_index(
-        {"citations_count.source": 1, "citations_count.count": 1})
-    db["works"].create_index({"titles.source": 1, "titles.title": 1})
-    db["affiliations"].create_index({"products_count": -1})
-    db["person"].create_index({"products_count": -1})
-    db["works"].create_index(
-        {"types.source": 1, "types.type": 1, "types.code": 1})
+    db["works"].create_index({"external_ids.id": 1})
+
+    # Multi-source citations structure.
+    db["works"].create_index({"citations_count.source": 1, "citations_count.count": 1})
+
+    # Standalone filters (for $match before the sort).
     db["works"].create_index({"open_access.open_access_status": 1})
-    # https://github.com/colav/impactu/issues/418
-    db["works"].create_index(
-        {"subjects.subjects.level": 1, "subjects.subjects.name": 1})
-    # https://github.com/colav/impactu/issues/595
-    db["works"].create_index({"citations_count_openalex": 1})
-    db["affiliations"].create_index({"citations_count_openalex": 1})
     db["works"].create_index({"open_access.is_open_access": 1})
-    db["sources"].create_index({
-        "citations_count.source": 1,
-        "citations_count.count": 1
-    })
+    db["works"].create_index({"year_published": 1})
+    db["works"].create_index({"types.source": 1, "types.type": 1, "types.code": 1})
+    db["works"].create_index({"subjects.subjects.level": 1, "subjects.subjects.name": 1})
+    db["works"].create_index({"topics.id": 1})
+    db["works"].create_index({"primary_topic.id": 1})
+    db["works"].create_index({"countries": 1})
+
+    # --- Global search (without entity filter) ---
+    # sort=citations_desc
+    db["works"].create_index({"citations_count_openalex": -1, "_id": 1})
+    # sort=year_desc
+    db["works"].create_index({"year_published": -1, "_id": 1})
+    # sort=alphabetical_asc -> uses titles.source + titles.title
+    db["works"].create_index({"titles.source": 1, "titles.title": 1})
+
+    # --- By affiliations.id (institution/faculty/department/group research/products) ---
+    # sort=citations_desc
+    db["works"].create_index({"authors.affiliations.id": 1, "citations_count_openalex": -1, "_id": 1})
+    # sort=year_desc
+    db["works"].create_index({"authors.affiliations.id": 1, "year_published": -1, "_id": 1})
+    # H-index calculations
+    db["works"].create_index({"authors.affiliations.id": 1, "year_published": 1, "citations_count_openalex": 1})
+
+    # --- By authors.id (person research/products) ---
+    # sort=citations_desc
+    db["works"].create_index({"authors.id": 1, "citations_count_openalex": -1, "_id": 1})
+    # sort=year_desc
+    db["works"].create_index({"authors.id": 1, "year_published": -1, "_id": 1})
+    # H-index calculations
+    db["works"].create_index({"authors.id": 1, "year_published": 1, "citations_count_openalex": 1})
+
+    # --- By source.id ---
+    # sort=citations_desc
+    db["works"].create_index({"source.id": 1, "citations_count_openalex": -1, "_id": 1})
+    # sort=year_desc
+    db["works"].create_index({"source.id": 1, "year_published": -1, "_id": 1})
+
+    # =========================================================
+    # AFFILIATIONS COLLECTION
+    # =========================================================
+    db["affiliations"].create_index({"products_count": -1})
+    db["affiliations"].create_index({"types.type": 1})
+    db["affiliations"].create_index({"external_ids.id": 1})
+    db["affiliations"].create_index({"names.name": 1})
+    db["affiliations"].create_index({"names.name": "text"})
+    # sort=citations_desc filtered by type
+    db["affiliations"].create_index({"types.type": 1, "citations_count_openalex": -1, "_id": 1})
+    # sort=products_desc filtered by type
+    db["affiliations"].create_index({"types.type": 1, "products_count": -1, "_id": 1})
+    # H-index
+    db["affiliations"].create_index({"types.type": 1, "h_index": -1, "_id": 1})
+
+    # =========================================================
+    # PERSON COLLECTION
+    # =========================================================
+    db["person"].create_index({"full_name": 1})
+    db["person"].create_index({"full_name": "text"})
+    db["person"].create_index({"external_ids.id": 1})
+    db["person"].create_index({"affiliations.id": 1})
+    # sort=products_desc
+    db["person"].create_index({"products_count": -1, "_id": 1})
+    # sort=citations_desc
+    db["person"].create_index({"citations_count_openalex": -1, "_id": 1})
+    # H-index
+    db["person"].create_index({"h_index": -1, "_id": 1})
+    db["person"].create_index({"h5_index": -1, "_id": 1})
+
+    # =========================================================
+    # SOURCES COLLECTION
+    # =========================================================
+    db["sources"].create_index({"citations_count.source": 1, "citations_count.count": 1})
     db["sources"].create_index({"products_count": -1, "_id": 1})
     db["sources"].create_index({"global_products_count": -1, "_id": 1})
     db["sources"].create_index({"global_citations_count": -1, "_id": 1})
@@ -37,25 +103,15 @@ def create_indexes(db):
     db["sources"].create_index({"names.name": "text"})
     db["sources"].create_index({"types.type": 1})
     db["sources"].create_index({"publisher.country_code": 1})
-    db["sources"].create_index({
-        "external_ids.source": 1,
-        "external_ids.id": 1
-    })
+    db["sources"].create_index({"external_ids.source": 1, "external_ids.id": 1})
     db["sources"].create_index({"subjects.name": 1})
-    db["sources"].create_index({
-        "ranking.source": 1,
-        "ranking.to_date": -1,
-        "ranking.rank": 1
-    })
+    db["sources"].create_index({"ranking.source": 1, "ranking.to_date": -1, "ranking.rank": 1})
     db["sources"].create_index({"_id": 1, "ranking": 1})
     db["sources"].create_index({"open_access_status": 1})
+    db["sources"].create_index({"open_access_start_year": 1})
     db["sources"].create_index({"scimago_best_quartile": 1})
     db["sources"].create_index({"apc.apc_usd": 1})
-    db["sources"].create_index({"open_access_start_year": 1})
     db["sources"].create_index({"apc.charges": 1})
     db["sources"].create_index({"publication_time_weeks": 1})
     db["sources"].create_index({"licenses.type": 1})
     db["sources"].create_index({"topics.id": 1})
-    # H-index and H5-index calculations require these indexes to be efficient
-    db["works"].create_index({"authors.id": 1, "year_published": 1, "citations_count_openalex": 1})
-    db["works"].create_index({"authors.affiliations.id": 1, "year_published": 1, "citations_count_openalex": 1})


### PR DESCRIPTION
This PR add the h-index and h5-index denormalization flow and keeps the implementation simple and maintainable. It's optimized so it takes the less ammount of time to process.

The local full-database test completed successfully with the following results:

- person: 97.05 seconds
- affiliations: 13.54 seconds

**Total: 112.14 seconds**

Validation examples from the database:
```
{"_id": "0000177733", "full_name": "Diego Alejandro Restrepo Quintero", "h5_index": 7, "h_index": 14}

{"names": [{"source": "ror", "name": "Universidad de Antioquia", "lang": "en"}], "h5_index": 56, "h_index": 129}
```

Issue relacionado: https://github.com/colav/impactu/issues/672