### PR TITLE
[Kahi_*_sources] Fixes sources ingestion for ImpactU run

### DIFF
--- a/Kahi_openalex_sources/kahi_openalex_sources/Kahi_openalex_sources.py
+++ b/Kahi_openalex_sources/kahi_openalex_sources/Kahi_openalex_sources.py
@@ -77,7 +77,7 @@ def process_one(source, client, db_name, empty_source):
                 break
         if not name_found:
             source_db["names"].append(
-                {"name": source["display_name"], "lang": "en", "source": "openalex"})
+                {"lang": "en", "name": source["display_name"], "source": "openalex"})
         if "is_oa" in source.keys():
             is_oa = source.get("is_oa")
             apc = source.get("apc_prices")
@@ -118,7 +118,7 @@ def process_one(source, client, db_name, empty_source):
         entry["updated"] = [
             {"source": "openalex", "time": int(time())}]
         entry["names"].append(
-            {"name": source["display_name"], "lang": "en", "source": "openalex"})
+            {"lang": "en", "name": source["display_name"], "source": "openalex"})
         entry["external_ids"].append(
             {"source": "openalex", "id": source["id"]})
         if "issn" in source.keys():

--- a/Kahi_publindex_sources/README.md
+++ b/Kahi_publindex_sources/README.md
@@ -4,11 +4,12 @@
 Kahi will use this plugin to insert or update journal source records from a Publindex MongoDB collection.
 
 # Description
-Plugin that reads records from a MongoDB collection (for example `publindex_data`) and upserts them in CoLav's `sources` collection format.
+Plugin that reads records from MongoDB Publindex collections and upserts them in CoLav's `sources` collection format.
 
 The implementation separates:
 - insertion of new source records
 - update of existing source records
+- national Publindex ingestion before international homologation ingestion
 
 # Installation
 You can install from source:
@@ -25,7 +26,8 @@ pip3 install kahi_publindex_sources
 Software dependencies are installed with the package.
 You need:
 - a target Kahi MongoDB database
-- a source MongoDB database/collection with Publindex records
+- a source MongoDB database with national Publindex records, usually `publindex_data`
+- optionally, an `international` collection with homologation records
 
 # Usage
 To use this plugin you must have Kahi installed and define a workflow like:
@@ -40,9 +42,14 @@ workflow:
   publindex_sources:
     database_url: localhost:27017
     database_name: publindex
-    collection_name: publindex_data
+    national_collection_name: publindex_data
+    international_collection_name: international
     verbose: 5
 ```
+
+The plugin processes `national_collection_name` first. If `national_collection_name` is set to `national` and that collection does not exist, it falls back to `publindex_data`.
+
+If `international_collection_name` exists, it is processed after the national collection. International records use `nombreRevista`, `calificacion`, `issns`, and `vigencia`; rankings are stored with source `publindex`.
 
 # License
 BSD-3-Clause License

--- a/Kahi_publindex_sources/kahi_publindex_sources/Kahi_publindex_sources.py
+++ b/Kahi_publindex_sources/kahi_publindex_sources/Kahi_publindex_sources.py
@@ -1,5 +1,6 @@
 from datetime import datetime as dt
 from time import time
+import calendar
 import re
 
 from kahi.KahiBase import KahiBase
@@ -27,17 +28,37 @@ class Kahi_publindex_sources(KahiBase):
             )
 
         self.publindex_db = self.publindex_client[source_cfg["database_name"]]
-        if source_cfg["collection_name"] not in self.publindex_db.list_collection_names():
+        collection_names = self.publindex_db.list_collection_names()
+        national_collection_name = source_cfg.get(
+            "national_collection_name",
+            source_cfg.get("collection_name", "national"),
+        )
+        if national_collection_name not in collection_names and national_collection_name == "national":
+            national_collection_name = "publindex_data"
+
+        if national_collection_name not in collection_names:
             raise RuntimeError(
-                f'Collection {source_cfg["collection_name"]} was not found on database {source_cfg["database_name"]}'
+                f'Collection {national_collection_name} was not found on database {source_cfg["database_name"]}'
             )
 
-        self.publindex_collection = self.publindex_db[source_cfg["collection_name"]]
+        self.publindex_collection = self.publindex_db[national_collection_name]
+
+        international_collection_name = source_cfg.get(
+            "international_collection_name", "international")
+        self.publindex_international_collection = None
+        if international_collection_name in collection_names:
+            self.publindex_international_collection = self.publindex_db[
+                international_collection_name
+            ]
+
         self.verbose = source_cfg.get("verbose", 0)
 
         self.inserted = 0
         self.updated = 0
         self.skipped = 0
+        self.international_inserted = 0
+        self.international_updated = 0
+        self.international_skipped = 0
 
     def _normalize_text(self, value):
         if value is None:
@@ -80,6 +101,48 @@ class Kahi_publindex_sources(KahiBase):
         end = int(dt(year, 12, 31, 23, 59, 59).timestamp())
         return (start, end)
 
+    def _vigencia_bounds(self, value):
+        text = self._normalize_text(value)
+        if not text:
+            return (None, None)
+
+        month_map = {
+            "ene": 1,
+            "feb": 2,
+            "mar": 3,
+            "abr": 4,
+            "may": 5,
+            "jun": 6,
+            "jul": 7,
+            "ago": 8,
+            "sep": 9,
+            "sept": 9,
+            "oct": 10,
+            "nov": 11,
+            "dic": 12,
+        }
+        matches = re.findall(r"([A-Za-zÁÉÍÓÚáéíóúñÑ]{3,})\s+(\d{4})", text)
+        if len(matches) >= 2:
+            start_month = month_map.get(matches[0][0].lower()[:4])
+            if start_month is None:
+                start_month = month_map.get(matches[0][0].lower()[:3])
+            end_month = month_map.get(matches[-1][0].lower()[:4])
+            if end_month is None:
+                end_month = month_map.get(matches[-1][0].lower()[:3])
+            start_year = int(matches[0][1])
+            end_year = int(matches[-1][1])
+            if start_month and end_month:
+                last_day = calendar.monthrange(end_year, end_month)[1]
+                return (
+                    int(dt(start_year, start_month, 1, 0, 0, 0).timestamp()),
+                    int(dt(end_year, end_month, last_day, 23, 59, 59).timestamp()),
+                )
+
+        years = re.findall(r"\d{4}", text)
+        if years:
+            return self._year_bounds(years[-1])
+        return (None, None)
+
     def _ensure_required_fields(self, entry):
         list_fields = [
             "updated",
@@ -115,7 +178,11 @@ class Kahi_publindex_sources(KahiBase):
         if not name:
             return
         for rec in entry["names"]:
-            if rec.get("name") == name and rec.get("source") == source:
+            if rec.get("name") != name:
+                continue
+            if rec.get("source") != source:
+                continue
+            if rec.get("lang", "") == lang:
                 return
         entry["names"].append({"lang": lang, "name": name, "source": source})
 
@@ -128,14 +195,14 @@ class Kahi_publindex_sources(KahiBase):
                 return
         entry["external_ids"].append({"source": source, "id": identifier})
 
-    def _upsert_ranking(self, entry, rank_value, from_date, to_date):
+    def _upsert_ranking(self, entry, rank_value, from_date, to_date, source="publindex"):
         rank_value = self._normalize_text(rank_value)
         if not rank_value:
             return
 
         for rec in entry["ranking"]:
             if (
-                rec.get("source") == "publindex" and rec.get("from_date") == from_date and rec.get("to_date") == to_date
+                rec.get("source") == source and rec.get("from_date") == from_date and rec.get("to_date") == to_date
             ):
                 rec["rank"] = rank_value
                 rec["order"] = None
@@ -147,7 +214,7 @@ class Kahi_publindex_sources(KahiBase):
                 "to_date": to_date,
                 "rank": rank_value,
                 "order": None,
-                "source": "publindex",
+                "source": source,
             }
         )
 
@@ -240,6 +307,25 @@ class Kahi_publindex_sources(KahiBase):
             "publindex_id": self._normalize_numeric_id(reg.get("id_revista_p")),
         }
 
+    def _extract_international_identity(self, reg):
+        issns = reg.get("issns", [])
+        if isinstance(issns, str):
+            issns = re.split(r"[,;|/\\]+", issns)
+        elif not isinstance(issns, list):
+            issns = [issns]
+
+        normalized_issns = []
+        for issn in issns:
+            normalized = self._normalize_issn(issn)
+            if normalized and normalized not in normalized_issns:
+                normalized_issns.append(normalized)
+
+        return {
+            "name": self._normalize_text(reg.get("nombreRevista")),
+            "issns": normalized_issns,
+            "rank": self._normalize_text(reg.get("calificacion")),
+        }
+
     def _find_existing_source(self, reg):
         identity = self._extract_identity(reg)
         ids = [
@@ -257,13 +343,25 @@ class Kahi_publindex_sources(KahiBase):
             return self.collection.find_one({"names.name": identity["name"]})
         return None
 
+    def _find_existing_international_source(self, reg):
+        identity = self._extract_international_identity(reg)
+        if identity["issns"]:
+            doc = self.collection.find_one(
+                {"external_ids.id": {"$in": identity["issns"]}})
+            if doc:
+                return doc
+
+        if identity["name"]:
+            return self.collection.find_one({"names.name": identity["name"]})
+        return None
+
     def insert_source(self, reg):
         entry = self.empty_source()
         entry = self._ensure_required_fields(entry)
         identity = self._extract_identity(reg)
 
         self._upsert_updated(entry, "publindex")
-        self._append_name(entry, identity["name"], "es", "publindex")
+        self._append_name(entry, identity["name"], "", "publindex")
         self._append_external_id(entry, "issn", identity["issn_p"])
         self._append_external_id(entry, "issn_l", identity["issn_l"])
         self._append_external_id(entry, "publindex", identity["publindex_id"])
@@ -291,7 +389,7 @@ class Kahi_publindex_sources(KahiBase):
         identity = self._extract_identity(reg)
 
         self._upsert_updated(entry, "publindex")
-        self._append_name(entry, identity["name"], "es", "publindex")
+        self._append_name(entry, identity["name"], "", "publindex")
         self._append_external_id(entry, "issn", identity["issn_p"])
         self._append_external_id(entry, "issn_l", identity["issn_l"])
         self._append_external_id(entry, "publindex", identity["publindex_id"])
@@ -321,6 +419,53 @@ class Kahi_publindex_sources(KahiBase):
         del entry["_id"]
         self.collection.update_one({"_id": doc_id}, {"$set": entry})
         self.updated += 1
+
+    def insert_international_source(self, reg):
+        entry = self.empty_source()
+        entry = self._ensure_required_fields(entry)
+        identity = self._extract_international_identity(reg)
+
+        self._upsert_updated(entry, "publindex")
+        self._append_name(
+            entry, identity["name"], "", "publindex")
+        for issn in identity["issns"]:
+            self._append_external_id(entry, "issn", issn)
+
+        from_date, to_date = self._vigencia_bounds(reg.get("vigencia"))
+        self._upsert_ranking(
+            entry,
+            identity["rank"],
+            from_date,
+            to_date,
+            source="publindex",
+        )
+
+        self.collection.insert_one(entry)
+        self.international_inserted += 1
+
+    def update_international_source(self, reg, entry):
+        entry = self._ensure_required_fields(entry)
+        identity = self._extract_international_identity(reg)
+
+        self._upsert_updated(entry, "publindex")
+        self._append_name(
+            entry, identity["name"], "", "publindex")
+        for issn in identity["issns"]:
+            self._append_external_id(entry, "issn", issn)
+
+        from_date, to_date = self._vigencia_bounds(reg.get("vigencia"))
+        self._upsert_ranking(
+            entry,
+            identity["rank"],
+            from_date,
+            to_date,
+            source="publindex",
+        )
+
+        doc_id = entry["_id"]
+        del entry["_id"]
+        self.collection.update_one({"_id": doc_id}, {"$set": entry})
+        self.international_updated += 1
 
     def process_publindex(self):
         cursor = self.publindex_collection.find(no_cursor_timeout=True)
@@ -355,9 +500,45 @@ class Kahi_publindex_sources(KahiBase):
                 f"Publindex finished: inserted={self.inserted}, updated={self.updated}, skipped={self.skipped}"
             )
 
+    def process_publindex_international(self):
+        if self.publindex_international_collection is None:
+            if self.verbose >= 4:
+                print("Publindex international skipped: collection not found")
+            return
+
+        cursor = self.publindex_international_collection.find(
+            no_cursor_timeout=True)
+        try:
+            for idx, reg in enumerate(cursor, start=1):
+                identity = self._extract_international_identity(reg)
+                has_identity = bool(identity["name"] or identity["issns"])
+                if not has_identity:
+                    self.international_skipped += 1
+                    continue
+
+                source_db = self._find_existing_international_source(reg)
+                if source_db:
+                    self.update_international_source(reg, source_db)
+                else:
+                    self.insert_international_source(reg)
+
+                if self.verbose >= 5 and idx % 1000 == 0:
+                    print(f"Processed {idx} international records")
+        finally:
+            cursor.close()
+
+        if self.verbose >= 4:
+            print(
+                "Publindex international finished: "
+                f"inserted={self.international_inserted}, "
+                f"updated={self.international_updated}, "
+                f"skipped={self.international_skipped}"
+            )
+
     def run(self):
         start_time = time()
         self.process_publindex()
+        self.process_publindex_international()
         print("Execution time: {} minutes".format(
             round((time() - start_time) / 60, 2)))
         self.client.close()

--- a/Kahi_scienti_sources/kahi_scienti_sources/Kahi_scienti_sources.py
+++ b/Kahi_scienti_sources/kahi_scienti_sources/Kahi_scienti_sources.py
@@ -3,6 +3,7 @@ from pymongo import MongoClient, InsertOne, UpdateOne, ASCENDING
 from time import time
 from langid import classify
 from kahi_impactu_utils.Utils import check_date_format
+import re
 
 
 class Kahi_scienti_sources(KahiBase):
@@ -54,6 +55,46 @@ class Kahi_scienti_sources(KahiBase):
                 collection.create_index(
                     [("details.article.journal.TXT_ISSN_SEP", ASCENDING)])
                 client.close()
+
+    def _normalize_issn(self, value):
+        if value is None:
+            return ""
+        text = str(value).strip().upper()
+        text = text.replace("-", "").replace(" ", "")
+        if len(text) != 8:
+            return ""
+        if not re.match(r"^[0-9]{7}[0-9X]$", text):
+            return ""
+        return f"{text[:4]}-{text[4:]}"
+
+    def _issn_values(self, value):
+        normalized = self._normalize_issn(value)
+        if not normalized:
+            return []
+        return [normalized, normalized.replace("-", "")]
+
+    def _journal_query_for_issn(self, issn):
+        values = self._issn_values(issn)
+        return {
+            "$or": [
+                {"details.article.journal.TXT_ISSN_SEP": {"$in": values}},
+                {"details.article.journal.TXT_ISSN": {"$in": values}},
+                {"details.article.journal_others.TXT_ISSN": {"$in": values}},
+            ]
+        }
+
+    def _find_source_by_issn(self, issn):
+        values = self._issn_values(issn)
+        if not values:
+            return None
+        return self.collection.find_one({"external_ids.id": {"$in": values}})
+
+    def _append_external_id(self, entry, source, identifier):
+        identifier = str(identifier)
+        for ext in entry["external_ids"]:
+            if ext.get("source") == source and str(ext.get("id")) == identifier:
+                return
+        entry["external_ids"].append({"source": source, "id": identifier})
 
     def process_editorials(self, editorials_list):
         unique_codes = list(set(editorials_list))
@@ -149,14 +190,13 @@ class Kahi_scienti_sources(KahiBase):
         if "TPO_REVISTA" in journal.keys():
             entry["types"].append(
                 {"source": "scienti", "type": journal["TPO_REVISTA"]})
-        entry["external_ids"].append(
-            {"source": "scienti", "id": journal["COD_REVISTA"]})
+        self._append_external_id(entry, "scienti", journal["COD_REVISTA"])
 
         rankings_list = []
         ranks = []
         dates = [(rank["from_date"], rank["to_date"])
                  for rank in entry["ranking"] if rank["source"] == "scienti"]
-        for reg_scienti in self.scienti_collection.find({"details.article.journal.TXT_ISSN_SEP": issn}):
+        for reg_scienti in self.scienti_collection.find(self._journal_query_for_issn(issn)):
             paper = None
             journal = None
             if "details" not in reg_scienti.keys():
@@ -190,19 +230,12 @@ class Kahi_scienti_sources(KahiBase):
             else:
                 idx = ranks.index(journal["TPO_CLASIFICACION"])
                 date1, date2 = dates[idx]
-
-                try:
+                if isinstance(date1, (int, float)) and isinstance(date2, (int, float)):
                     if date1 > DTA_CREACION:
                         date1 = DTA_CREACION
                     if date2 < DTA_CREACION:
                         date2 = DTA_CREACION
                     dates[idx] = (date1, date2)
-                except Exception as e:
-                    print(e)
-                    date1 = ''
-                    date2 = ''
-
-                dates[idx] = ('', '')
 
         self.collection.update_one({"_id": entry["_id"]}, {"$set": {
             "types": entry["types"],
@@ -220,30 +253,31 @@ class Kahi_scienti_sources(KahiBase):
         issn_list = list(self.scienti_collection.distinct(
             "details.article.journal.TXT_ISSN_SEP"))
         issn_list.extend(self.scienti_collection.distinct(
+            "details.article.journal.TXT_ISSN"))
+        issn_list.extend(self.scienti_collection.distinct(
             "details.article.journal_others.TXT_ISSN"))
+        issn_list = sorted(
+            {
+                self._normalize_issn(issn)
+                for issn in issn_list
+                if self._normalize_issn(issn)
+            }
+        )
         # extracting the editorial codes
         editorials_list = list(self.scienti_collection.distinct(
             "details.book.editorial.COD_EDITORIAL"))
         editorials_list = [str(code) for code in editorials_list]
 
-        for issn in set(issn_list):
-            reg_db = self.collection.find_one({"external_ids.id": issn})
+        for issn in issn_list:
+            reg_db = self._find_source_by_issn(issn)
             if reg_db:
                 reg_scienti = self.scienti_collection.find_one(
-                    {"details.article.journal.TXT_ISSN_SEP": issn})
+                    self._journal_query_for_issn(issn))
                 if reg_scienti:
                     self.update_scienti(reg_scienti, reg_db, issn)
-                else:
-                    reg_scienti = self.scienti_collection.find_one(
-                        {"details.article.journal_others.TXT_ISSN": issn})
-                    if reg_scienti:
-                        self.update_scienti(reg_scienti, reg_db, issn)
             else:
                 reg_scienti = self.scienti_collection.find_one(
-                    {"details.article.journal.TXT_ISSN_SEP": issn})
-                if not reg_scienti:
-                    reg_scienti = self.scienti_collection.find_one(
-                        {"details.article.journal_others.TXT_ISSN": issn})
+                    self._journal_query_for_issn(issn))
                 if reg_scienti:
                     journal = None
                     if "details" not in reg_scienti.keys():
@@ -265,10 +299,8 @@ class Kahi_scienti_sources(KahiBase):
                     lang = classify(journal["TXT_NME_REVISTA"])[0]
                     entry["names"] = [
                         {"lang": lang, "name": journal["TXT_NME_REVISTA"], "source": "scienti"}]
-                    entry["external_ids"].append(
-                        {"source": "issn", "id": journal["TXT_ISSN_SEP"] if "TXT_ISSN_SEP" in journal.keys() else journal["TXT_ISSN"]})
-                    entry["external_ids"].append(
-                        {"source": "scienti", "id": journal["COD_REVISTA"]})
+                    entry["external_ids"].append({"source": "issn", "id": issn})
+                    self._append_external_id(entry, "scienti", journal["COD_REVISTA"])
                     if "TPO_REVISTA" in journal.keys():
                         entry["types"].append(
                             {"source": "scienti", "type": journal["TPO_REVISTA"]})
@@ -278,7 +310,7 @@ class Kahi_scienti_sources(KahiBase):
                     rankings_list = []
                     ranks = []
                     dates = []
-                    for reg_scienti in self.scienti_collection.find({"details.article.journal.TXT_ISSN_SEP": issn}):
+                    for reg_scienti in self.scienti_collection.find(self._journal_query_for_issn(issn)):
                         paper = None
                         journal = None
                         if "details" not in reg_scienti.keys():
@@ -314,17 +346,12 @@ class Kahi_scienti_sources(KahiBase):
                                 # if is already ranked but dates changed
                                 idx = ranks.index(journal["TPO_CLASIFICACION"])
                                 date1, date2 = dates[idx]
-                                try:
+                                if isinstance(date1, (int, float)) and isinstance(date2, (int, float)):
                                     if date1 > DTA_CREACION:
                                         date1 = DTA_CREACION
                                     if date2 < DTA_CREACION:
                                         date2 = DTA_CREACION
-                                except Exception as e:
-                                    print(e)
-                                    date1 = ''
-                                    date2 = ''
-
-                                dates[idx] = (date1, date2)
+                                    dates[idx] = (date1, date2)
                     entry["ranking"] = rankings_list
                     self.collection.insert_one(entry)
 

--- a/Kahi_scimago_sources/README.md
+++ b/Kahi_scimago_sources/README.md
@@ -4,7 +4,7 @@
 Kahi will use this plugin to insert or update the journal information from scimago
 
 # Description
-Plugin that reads the information from scimago ranking csv file to update or insert the information of the journals in CoLav's database format.
+Plugin that reads ScimagoJR ranking records from MongoDB to update or insert journal information in CoLav's database format.
 
 # Installation
 You could download the repository from github. Go into the folder where the setup.py is located and run
@@ -18,7 +18,7 @@ pip3 install kahi_scimago_sources
 
 ## Dependencies
 Software dependencies will automatically be installed when installing the plugin.
-The user must have at least one file fomr scimago report of journal rankings that can be downloaded from [scimago website](https://www.scimagojr.com/journalrank.php "Scimago journal rankings"). The file **MUST** be named as the download from scimago suggests i.e. scimagojr 2023.csv
+The user must have ScimagoJR data loaded in MongoDB. The expected records are the ones produced by the `scimagojr_capture` extractor, with at least `Sourceid`, `year`, `Issn`, `Title`, `Rank`, `SJR`, `SJR Best Quartile`, `H index`, `Categories`, `Country`, `Publisher`, and `Type`.
 
 # Usage
 To use this plugin you must have kahi installed in your system and construct a yaml file such as
@@ -30,32 +30,17 @@ config:
   log_collection: log
 workflow:
   scimago_sources:
-    file_path:
-      - scimago/scimagojr 2020.csv
+    database_url: localhost:27017
+    database_name: scimagojr
+    collection_name: scimagojr
+    verbose: 4
 ```
-Where file_path under scimago_sources task is the full path where the scimago csv is located.
-
-I you have several scimago files use the yaml structure as shown below
-```yaml
-config:
-  database_url: localhost
-  database_name: kahi_test
-  log_database: kahi_test
-  log_collection: log
-workflow:
-  scimago_sources:
-    file_path: 
-      - /current/data/scimago/scimagojr 1999.csv
-      - /current/data/scimago/scimagojr 2000.csv
-      - /current/data/scimago/scimagojr 2001.csv
-      - /current/data/scimago/scimagojr 2002.csv
-```
+Where `database_url`, `database_name`, and `collection_name` under `scimago_sources` point to the MongoDB collection with ScimagoJR records.
 
 # License
 BSD-3-Clause License 
 
 # Links
 http://colav.udea.edu.co/
-
 
 

--- a/Kahi_scimago_sources/kahi_scimago_sources/Kahi_scimago_sources.py
+++ b/Kahi_scimago_sources/kahi_scimago_sources/Kahi_scimago_sources.py
@@ -25,12 +25,51 @@ class Kahi_scimago_sources(KahiBase):
 
         self.collection.create_index("external_ids.id")
 
-        self.scimago_file_paths = self.config["scimago_sources"]["file_path"]
+        self.scimago_config = self.config["scimago_sources"]
+        self.scimago_file_paths = self.scimago_config.get("file_path")
+        self.scimago_collection = None
+
+        if not self.scimago_file_paths:
+            self.scimago_client = MongoClient(self.scimago_config["database_url"])
+            database_name = self.scimago_config["database_name"]
+            collection_name = self.scimago_config["collection_name"]
+
+            if database_name not in self.scimago_client.list_database_names():
+                raise Exception(
+                    f"Database {database_name} missing from {self.scimago_config['database_url']}"
+                )
+
+            self.scimago_db = self.scimago_client[database_name]
+            if collection_name not in self.scimago_db.list_collection_names():
+                raise Exception(
+                    f"Collection {database_name}.{collection_name} missing from {database_name}"
+                )
+
+            self.scimago_collection = self.scimago_db[collection_name]
+
+        self.verbose = self.scimago_config.get("verbose", 0)
 
         self.already_in_db = []
 
+    def _get_value(self, reg, key, default=None):
+        if hasattr(reg, "get"):
+            value = reg.get(key, default)
+        else:
+            value = reg[key] if key in reg else default
+        return default if value is None else value
+
     def _normalize_spaces(self, s: str) -> str:
         return " ".join(s.strip().split())
+
+    def _iter_issns(self, issn_list):
+        if not issn_list:
+            return []
+        issns = []
+        for issn in str(issn_list).split(","):
+            issn = issn.strip()
+            if len(issn) >= 8:
+                issns.append(issn)
+        return issns
 
     def parse_scimago_categories(self, raw: str):
         """
@@ -80,9 +119,9 @@ class Kahi_scimago_sources(KahiBase):
 
         from_ts = int(self.scimago_start_ts)
         to_ts = int(self.scimago_end_ts)
-        order_val = int(sjr["Rank"]) if sjr.get("Rank") else None
+        order_val = int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None
 
-        cats = self.parse_scimago_categories(sjr.get("Categories", ""))
+        cats = self.parse_scimago_categories(self._get_value(sjr, "Categories", ""))
 
         existing = set()
         for r in entry["ranking"]:
@@ -113,11 +152,14 @@ class Kahi_scimago_sources(KahiBase):
             entry["updated"].append(
                 {"source": "scimago", "time": int(time())})
 
+        found_scimago_name = False
         for name in entry["names"]:
-            if name == sjr["Title"]:
-                if name["source"] != "scimago":
-                    entry["names"].append(
-                        {"lang": "en", "name": sjr["Title"], "source": "scimago"})
+            if name.get("name") == self._get_value(sjr, "Title") and name.get("source") == "scimago":
+                found_scimago_name = True
+                break
+        if not found_scimago_name:
+            entry["names"].append(
+                {"lang": "en", "name": self._get_value(sjr, "Title"), "source": "scimago"})
         found_scimagoid = False
         for ext in entry["external_ids"]:
             if ext["source"] == "scimago":
@@ -125,17 +167,17 @@ class Kahi_scimago_sources(KahiBase):
                 break
         if not found_scimagoid:
             entry["external_ids"].append(
-                {"source": "scimago", "id": str(sjr["Sourceid"])})
+                {"source": "scimago", "id": str(self._get_value(sjr, "Sourceid"))})
         found_scimago_type = False
         for typ in entry["types"]:
             if typ["source"] == "scimago":
                 found_scimago_type = True
                 break
         if not found_scimago_type:
-            entry["types"].append({"source": "scimago", "type": sjr["Type"]})
+            entry["types"].append({"source": "scimago", "type": self._get_value(sjr, "Type")})
 
         ids = [extid["id"] for extid in entry["external_ids"]]
-        for extid in sjr["Issn"].split(","):
+        for extid in self._iter_issns(self._get_value(sjr, "Issn")):
             extid = extid.strip()
             extid = extid[:4] + "-" + extid[4:]
             if extid not in ids:
@@ -148,45 +190,45 @@ class Kahi_scimago_sources(KahiBase):
             entry["ranking"].append({
                 "to_date": self.scimago_end_ts,
                 "from_date": self.scimago_start_ts,
-                "rank": sjr["SJR Best Quartile"],
-                "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                "rank": self._get_value(sjr, "SJR Best Quartile"),
+                "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                 "source": "scimago Best Quartile"
             })
         if ("scimago hindex", self.scimago_start_ts, self.scimago_end_ts) not in rankings:
             entry["ranking"].append({
                 "to_date": self.scimago_end_ts,
                 "from_date": self.scimago_start_ts,
-                "rank": int(sjr["H index"]),
-                "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                "rank": int(self._get_value(sjr, "H index")),
+                "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                 "source": "scimago hindex"
             })
-        if sjr.get("Open Access") and sjr.get("Open Access Diamond"):
+        if self._get_value(sjr, "Open Access") and self._get_value(sjr, "Open Access Diamond"):
             oa_rec = ({
                 "provenance": "scimago",
-                "is_open_access": True if sjr.get("Open Access") == "Yes" else False,
-                "open_access_diamond": True if sjr.get("Open Access Diamond") == "Yes" else False
+                "is_open_access": True if self._get_value(sjr, "Open Access") == "Yes" else False,
+                "open_access_diamond": True if self._get_value(sjr, "Open Access Diamond") == "Yes" else False
             })
             if oa_rec not in entry["open_access"]:
                 entry["open_access"].append(oa_rec)
         if ("scimago", self.scimago_start_ts, self.scimago_end_ts) not in rankings:
-            if sjr["SJR"]:
+            if self._get_value(sjr, "SJR"):
                 rank = ""
-                if isinstance(sjr["SJR"], str):
-                    rank = float(sjr["SJR"].replace(",", "."))
+                if isinstance(self._get_value(sjr, "SJR"), str):
+                    rank = float(self._get_value(sjr, "SJR").replace(",", "."))
                 else:
-                    rank = sjr["SJR"]
+                    rank = self._get_value(sjr, "SJR")
                 entry["ranking"].append({
                     "to_date": self.scimago_end_ts,
                     "from_date": self.scimago_start_ts,
                     "rank": rank,
-                    "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                    "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                     "source": "scimago"
                 })
         # Upsert category rankings
         self.upsert_scimago_category_rankings(sjr, entry)
 
         scimago_subjects = []
-        for cat in sjr["Categories"].split(";"):
+        for cat in self._get_value(sjr, "Categories", "").split(";"):
             cat_clean = self._normalize_spaces(cat)
             m = self._CAT_RE.match(cat_clean)
             if m:
@@ -220,12 +262,13 @@ class Kahi_scimago_sources(KahiBase):
         self.collection.update_one({"_id": _id}, {"$set": entry})
 
     def process_scimago(self):
-        for issn_list in self.scimago["Issn"].unique():
+        for sjr in self.scimago:
+            issn_list = self._get_value(sjr, "Issn")
             db_found = False
             db_reg = None
             ext_ids = []
             found_issn = None
-            for issn in issn_list.split(","):
+            for issn in self._iter_issns(issn_list):
                 issn = issn.strip()
                 extid = issn[:4] + "-" + issn[4:]
                 db_reg = self.collection.find_one({"external_ids.id": extid})
@@ -236,90 +279,87 @@ class Kahi_scimago_sources(KahiBase):
                 ext_ids.append({"source": "issn", "id": extid})
             if db_found:
                 self.already_in_db.append(found_issn)
-                sjr = self.scimago[self.scimago["Issn"] == issn_list]
-                sjr = sjr.iloc[0]
                 self.update_scimago(sjr, db_reg)
             else:
                 entry = self.empty_source()
                 entry["updated"] = [{"source": "scimago", "time": int(time())}]
-                sjr = self.scimago[self.scimago["Issn"] == issn_list]
-                sjr = sjr.iloc[0]
                 entry["types"].append(
-                    {"source": "scimago", "type": sjr["Type"]})
+                    {"source": "scimago", "type": self._get_value(sjr, "Type")})
                 entry["external_ids"] = ext_ids
                 entry["external_ids"].append(
-                    {"source": "scimago", "id": int(sjr["Sourceid"])})
+                    {"source": "scimago", "id": int(self._get_value(sjr, "Sourceid"))})
                 entry["names"] = [
-                    {"lang": "en", "name": sjr["Title"], "source": "scimago"}]
+                    {"lang": "en", "name": self._get_value(sjr, "Title"), "source": "scimago"}]
                 country = None
                 try:
-                    if sjr["Country"] == "United States":
-                        sjr["Country"] = "United States of America"
-                    elif sjr["Country"] == "United Kingdom":
-                        sjr["Country"] = "United Kingdom of Great Britain and Northern Ireland"
-                    elif sjr["Country"] == "South Korea":
-                        sjr["Country"] = "Korea, Republic of"
-                    elif sjr["Country"] == "Czech Republic":
-                        sjr["Country"] = "Czechia"
-                    elif sjr["Country"] == "Taiwan":
-                        sjr["Country"] = "Taiwan, Province of China"
-                    elif sjr["Country"] == "Iran":
-                        sjr["Country"] = "Iran, Islamic Republic of"
-                    elif sjr["Country"] == "Moldova":
-                        sjr["Country"] = "Moldova, Republic of"
-                    elif sjr["Country"] == "Venezuela":
-                        sjr["Country"] = "Venezuela, Bolivarian Republic of"
-                    elif sjr["Country"] == "Macedonia":
-                        sjr["Country"] = "North Macedonia"
-                    elif sjr["Country"] == "Palestine":
-                        sjr["Country"] = "Palestine, State of"
-                    elif sjr["Country"] == "Turkey":
-                        sjr["Country"] = "Türkiye"
-                    elif sjr["Country"] == "Vatican City State":
-                        sjr["Country"] = "Holy See"
-                    elif sjr["Country"] == "Tanzania":
-                        sjr["Country"] = "Tanzania, United Republic of"
-                    elif sjr["Country"] == "Bolivia":
-                        sjr["Country"] = "Bolivia, Plurinational State of"
+                    country_name = self._get_value(sjr, "Country")
+                    if country_name == "United States":
+                        country_name = "United States of America"
+                    elif country_name == "United Kingdom":
+                        country_name = "United Kingdom of Great Britain and Northern Ireland"
+                    elif country_name == "South Korea":
+                        country_name = "Korea, Republic of"
+                    elif country_name == "Czech Republic":
+                        country_name = "Czechia"
+                    elif country_name == "Taiwan":
+                        country_name = "Taiwan, Province of China"
+                    elif country_name == "Iran":
+                        country_name = "Iran, Islamic Republic of"
+                    elif country_name == "Moldova":
+                        country_name = "Moldova, Republic of"
+                    elif country_name == "Venezuela":
+                        country_name = "Venezuela, Bolivarian Republic of"
+                    elif country_name == "Macedonia":
+                        country_name = "North Macedonia"
+                    elif country_name == "Palestine":
+                        country_name = "Palestine, State of"
+                    elif country_name == "Turkey":
+                        country_name = "Türkiye"
+                    elif country_name == "Vatican City State":
+                        country_name = "Holy See"
+                    elif country_name == "Tanzania":
+                        country_name = "Tanzania, United Republic of"
+                    elif country_name == "Bolivia":
+                        country_name = "Bolivia, Plurinational State of"
 
                     country = iso3166.countries_by_name.get(
-                        sjr["Country"].upper()).alpha2
+                        country_name.upper()).alpha2
                 except Exception as e:
-                    print(e, sjr["Country"])
+                    print(e, self._get_value(sjr, "Country"))
                 if country:
                     entry["publisher"] = {
-                        "country_code": country, "name": sjr["Publisher"]}
+                        "country_code": country, "name": self._get_value(sjr, "Publisher")}
                 entry["ranking"].append({
-                    "to_date": 1640995199,
-                    "from_date": 1640995199,
-                    "rank": sjr["SJR Best Quartile"],
-                    "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                    "to_date": self.scimago_end_ts,
+                    "from_date": self.scimago_start_ts,
+                    "rank": self._get_value(sjr, "SJR Best Quartile"),
+                    "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                     "source": "scimago Best Quartile"
                 })
                 entry["ranking"].append({
-                    "to_date": 1640995199,
-                    "from_date": 1640995199,
-                    "rank": int(sjr["H index"]),
-                    "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                    "to_date": self.scimago_end_ts,
+                    "from_date": self.scimago_start_ts,
+                    "rank": int(self._get_value(sjr, "H index")),
+                    "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                     "source": "scimago hindex"
                 })
-                if sjr.get("Open Access") and sjr.get("Open Access Diamond"):
+                if self._get_value(sjr, "Open Access") and self._get_value(sjr, "Open Access Diamond"):
                     entry["open_access"].append({
                         "provenance": "scimago",
-                        "is_open_access": True if sjr.get("Open Access") == "Yes" else False,
-                        "open_access_diamond": True if sjr.get("Open Access Diamond") == "Yes" else False
+                        "is_open_access": True if self._get_value(sjr, "Open Access") == "Yes" else False,
+                        "open_access_diamond": True if self._get_value(sjr, "Open Access Diamond") == "Yes" else False
                     })
-                if sjr["SJR"]:
+                if self._get_value(sjr, "SJR"):
                     rank = ""
-                    if isinstance(sjr["SJR"], str):
-                        rank = float(sjr["SJR"].replace(",", "."))
+                    if isinstance(self._get_value(sjr, "SJR"), str):
+                        rank = float(self._get_value(sjr, "SJR").replace(",", "."))
                     else:
-                        rank = sjr["SJR"]
+                        rank = self._get_value(sjr, "SJR")
                     entry["ranking"].append({
-                        "to_date": 1640995199,
-                        "from_date": 1640995199,
+                        "to_date": self.scimago_end_ts,
+                        "from_date": self.scimago_start_ts,
                         "rank": rank,
-                        "order": int(sjr["Rank"]) if sjr["Rank"] else None,
+                        "order": int(self._get_value(sjr, "Rank")) if self._get_value(sjr, "Rank") else None,
                         "source": "scimago"
                     })
 
@@ -327,7 +367,7 @@ class Kahi_scimago_sources(KahiBase):
                 self.upsert_scimago_category_rankings(sjr, entry)
 
                 scimago_subjects = []
-                for cat in sjr["Categories"].split(";"):
+                for cat in self._get_value(sjr, "Categories", "").split(";"):
                     cat_clean = self._normalize_spaces(cat)
                     m = self._CAT_RE.match(cat_clean)
                     if m:
@@ -347,14 +387,28 @@ class Kahi_scimago_sources(KahiBase):
                 self.collection.insert_one(entry)
 
     def run(self):
-        for filename in self.scimago_file_paths:
-            self.scimago_year = int(
-                filename.replace(".csv", "").split(" ")[-1])
+        if self.scimago_file_paths:
+            for filename in self.scimago_file_paths:
+                self.scimago_year = int(
+                    filename.replace(".csv", "").split(" ")[-1])
+                self.scimago_start_ts = dt.strptime(
+                    "01 01 " + str(self.scimago_year), "%d %m %Y").timestamp()
+                self.scimago_end_ts = dt.strptime(
+                    "31 12 " + str(self.scimago_year), "%d %m %Y").timestamp()
+                self.scimago = read_csv(filename,
+                                        sep=";", dtype={"Sourceid": str}).to_dict("records")
+                self.process_scimago()
+            return 0
+
+        years = self.scimago_collection.distinct("year")
+        for year in sorted(years):
+            self.scimago_year = int(year)
             self.scimago_start_ts = dt.strptime(
                 "01 01 " + str(self.scimago_year), "%d %m %Y").timestamp()
             self.scimago_end_ts = dt.strptime(
                 "31 12 " + str(self.scimago_year), "%d %m %Y").timestamp()
-            self.scimago = read_csv(filename,
-                                    sep=";", dtype={"Sourceid": str})
+            self.scimago = self.scimago_collection.find(
+                {"year": self.scimago_year}, sort=[("Sourceid", 1)]
+            )
             self.process_scimago()
         return 0


### PR DESCRIPTION
-[Kahi_scimago_sources]: now consumes ScimagoJR from MongoDB (scimagojr.scimagojr) instead of CSV files, while keeping compatibility with file_path.
-[Kahi_publindex_sources]: now processes national Publindex first and then international; rankings are unified under source publindex.
-[Kahi_scienti_sources]: normalizes ISSNs, skips empty ISSNs, and fixes the case that created duplicate sources with only Scienti data.
-[Kahi_openalex_sources]: keeps the minor adjustment to the key order in the names dict.